### PR TITLE
added workarounds for bugs found in Foundation regarding percent escaping on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 let package = Package(
     name: "Monzo",
     dependencies: [
-        .Package(url: "https://github.com/marius-serban/S4.git", "0.12.2")
+        .Package(url: "https://github.com/marius-serban/S4.git", "0.12.2"),
+        .Package(url: "https://github.com/IBM-Swift/CCurl", "0.2.3") // temporary, for URL form encoding
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "Monzo",
     dependencies: [
         .Package(url: "https://github.com/marius-serban/S4.git", "0.12.2"),
-        .Package(url: "https://github.com/IBM-Swift/CCurl", "0.2.3") // temporary, for URL form encoding
+        .Package(url: "https://github.com/marius-serban/CcURL", "1.1.1") // temporary, for URL form encoding according to RFC 3986
     ]
 )

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ let package = Package(
 )
 ```
 
+### Ubuntu
+
+Install the development headers for cURL
+
+```shell
+sudo apt-get install libcurl4-openssl-dev
+```
+
 ## Support
 
 You can create a Github [issue](https://github.com/marius-serban/monzo-swift/issues/new) in this repository. When stating your issue be sure to add enough details about what's causing the problem and reproduction steps.

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -12,7 +12,7 @@ public final class Client {
     }
     
     public static func authorizationUri(clientId: String, redirectUri: String, nonce: String) throws -> URI {
-        let query = try "client_id=\(urlQueryPercentEncode(clientId))&redirect_uri=\(urlQueryPercentEncode(redirectUri))&state=\(urlQueryPercentEncode(nonce))"
+        let query = try "client_id=\(clientId.urlQueryPercentEncoded())&redirect_uri=\(redirectUri.urlQueryPercentEncoded())&state=\(nonce.urlQueryPercentEncoded())"
         
         return URI(scheme: "https", host: "auth.getmondo.co.uk", query: query)
     }
@@ -34,7 +34,7 @@ public final class Client {
     private static func authenticationRequest(authorizationCode: String, clientId: String, clientSecret: String) throws -> Request {
         let tokenUri = uri(withPath: "oauth2/token")
         let authHeaders = headers(contentType: "application/x-www-form-urlencoded; charset=utf-8")
-        let stringBody = try "grant_type=authorization_code&client_id=\(urlFormPercentEncode(clientId))&client_secret=\(urlFormPercentEncode(clientSecret))&redirect_uri=&code=\(urlFormPercentEncode(authorizationCode))"
+        let stringBody = try "grant_type=authorization_code&client_id=\(clientId.urlFormPercentEncoded())&client_secret=\(clientSecret.urlFormPercentEncoded())&redirect_uri=&code=\(authorizationCode.urlFormPercentEncoded())"
         guard let bodyData = stringBody.data(using: .utf8) else { throw ClientError.parameterEncodingError }
         let body = Body.buffer(Data([Byte](bodyData)))
         
@@ -57,17 +57,4 @@ public final class Client {
         return headers
     }
     
-}
-
-fileprivate func urlQueryPercentEncode(_ string: String) throws -> String {
-    guard let escaped = string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { throw ClientError.parameterEncodingError }
-    return escaped
-}
-
-fileprivate func urlFormPercentEncode(_ string: String) throws -> String {
-    // RFC 3986 allowed characters
-    var allowed = CharacterSet.alphanumerics
-    allowed.insert(charactersIn: "-._~ ") // workaround for SR-2509
-    guard let encoded = string.addingPercentEncoding(withAllowedCharacters: allowed) else { throw ClientError.parameterEncodingError }
-    return encoded.replacingOccurrences(of: " ", with: "+")
 }

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -66,7 +66,8 @@ fileprivate func urlQueryPercentEncode(_ string: String) throws -> String {
 
 fileprivate func urlFormPercentEncode(_ string: String) throws -> String {
     // RFC 3986 allowed characters
-    let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~ "))
+    var allowed = CharacterSet.alphanumerics
+    allowed.insert(charactersIn: "-._~ ") // workaround for SR-2509
     guard let encoded = string.addingPercentEncoding(withAllowedCharacters: allowed) else { throw ClientError.parameterEncodingError }
     return encoded.replacingOccurrences(of: " ", with: "+")
 }

--- a/Sources/String+PercentEncoding.swift
+++ b/Sources/String+PercentEncoding.swift
@@ -1,0 +1,29 @@
+import Foundation
+import CCurl
+
+extension String {
+    
+    func urlQueryPercentEncoded() throws -> String {
+        guard let escaped = addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { throw ClientError.parameterEncodingError }
+        return escaped
+    }
+    
+    func urlFormPercentEncoded() throws -> String {
+        let encodedComponents = components(separatedBy: " ").flatMap(cURLEncode)
+        return encodedComponents.joined(separator: "+")
+    }
+}
+
+//FIXME: remove cURL dependency once SR-3216 is fixed
+fileprivate func cURLEncode(string: String) -> String? {
+    guard !string.isEmpty else { return "" }
+    guard let handle = curl_easy_init() else { return nil }
+    guard let output = curl_easy_escape(handle, string, Int32(string.utf8.count)) else { return nil }
+    
+    let result = String(cString: output)
+    
+    curl_free(output)
+    curl_easy_cleanup(handle)
+    
+    return result
+}

--- a/Sources/String+PercentEncoding.swift
+++ b/Sources/String+PercentEncoding.swift
@@ -1,5 +1,5 @@
 import Foundation
-import CCurl
+import CcURL
 
 extension String {
     


### PR DESCRIPTION
- fix url form encoding on linux by using cURL instead of Foundation
- wokaround for CharacterSet union bug on linux